### PR TITLE
Add additional queries to athinfod for cluster

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+debathena-athinfod-cluster-config (1.8) unstable; urgency=low
+
+  * Add reactivate, kern.log and syslog to athinfod queries for cluster
+
+ -- Jonathan Reed <jdreed@mit.edu>  Mon, 27 Apr 2015 11:05:49 -0400
+
 debathena-athinfod-cluster-config (1.7) unstable; urgency=low
 
   [ Jonathan Reed ]

--- a/debian/debathena-athinfod-cluster-config.defs
+++ b/debian/debathena-athinfod-cluster-config.defs
@@ -6,3 +6,6 @@ install.log	/usr/lib/athinfod/is_cluster && cat /var/log/athena-install.log
 usb-hid		/usr/share/debathena-athinfod-cluster-config/usb-hid.py
 lsusb		/usr/lib/athinfod/is_cluster && lsusb
 dmesg		/usr/lib/athinfod/is_cluster && dmesg
+syslog		/usr/lib/athinfod/is_cluster && cat /var/log/syslog
+kern.log	/usr/lib/athinfod/is_cluster && cat /var/log/kern.log
+reactivate.log	/usr/lib/athinfod/is_cluster && cat /var/log/athena-reactivate


### PR DESCRIPTION
- Add the ability to query the reactivate log, kernel log and syslog,
  on cluster only, to help with remote debugging.
